### PR TITLE
minor fixes to install process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,47 @@
+# Workflow to test installation of the GOSTnetsraster package
+
+name: build-package
+
+# Controls when the action will run.
+# Triggers the workflow on push or pull request events as well as on
+# a monthly cron schedule. Also allows manual triggering.
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+  workflow_dispatch:
+
+# Set up jobs to spin up a virtual machine and build the package on each of
+# the operating systems we want to test on. We use a matrix to run the same
+# job on multiple operating systems and Python versions. At this time our
+# 'test' is very simple and consists of installing the package and trying
+# to import it.
+jobs:
+  test-os:
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }} with minconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+          auto-update-conda: true
+      - name: Print Python Version
+        run: |
+          python -V
+      - name: Install GOSTnetsraster
+        run: |
+          pip install .
+      - name: Test GOSTnetsraster install
+        run: |
+          python -c "import GOSTnetsraster"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 	"Intended Audience :: Developers",
 	"Operating System :: OS Independent",
 ]
-requires-python = ">=3"
+requires-python = ">=3.9"
 dependencies = [
     'rasterio',
     'geopandas',
@@ -43,4 +43,4 @@ docs = ["docutils==0.17.1", "jupyter-book>=1,<2"]
 "Source" = "https://github.com/worldbank/GOSTNets_Raster"
 
 [tool.setuptools_scm]
-write_to = "src/GOSTNetsRaster/_version.py"
+write_to = "src/GOSTnetsraster/_version.py"


### PR DESCRIPTION
closes #12 

fixes name of package in pyproject toml to properly create the _version.py file on the fly

adds continuous integration pipeline to test the build process on windows and linux for python versions >= 3.9